### PR TITLE
Add search result map handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@
 - Provider degradation warnings, source and accuracy badges, provenance details, and associated identity/phone metadata.
 - Social Mapping readiness in the Integrations workspace and platform startup checks.
 - Unit coverage for canonical map query construction and GeoJSON normalization.
+- A **Go to map** action for search results backed by explicit coordinates, including safe phone-to-associated-entity navigation.
 
 ### Changed
 
 - Core platform readiness now permits operation without X credentials; X availability remains a separate integration status.
 - X credential updates recreate both profile search and Social Mapping services.
 - Corrected package license metadata to GPL-3.0-only.
+- Coordinate handoffs now open the Map workspace, bypass text geocoding, and select the matching evidence record.
 
 ### Accuracy
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ Who Is It? is the native Electron investigation workspace for the [OSINT Service
 
 ## Workspaces
 
-- **Search** combines public profile, phone, and imported identity results. Provider failures stay isolated and source filters can avoid unnecessary live API calls.
+- **Search** combines public profile, phone, and imported identity results. Provider failures stay isolated and source filters can avoid unnecessary live API calls. Results with explicit coordinate evidence include a **Go to map** action.
 - **Map** calls the shared `/map/search` GeoJSON API directly. It provides place, radius, keyword, and source controls; an interactive Leaflet map; result and archive lists; provider warnings; source and accuracy badges; provenance; and associated profile/phone metadata.
 - **Datasets** previews and maps CSV, JSON, JSONL, or NDJSON into sparse entity records, including optional explicit coordinate evidence.
 - **Integrations** reports X/Tweepy, Twilio Lookup, local dataset, and Social Mapping readiness and supports protected credential replacement.
 - **History** keeps recent profile and phone searches on the local device.
 
 The Map workspace is native UI, not an embedded browser. The standalone [`social_mapping`](https://github.com/osint-services/social_mapping) client remains available for development and browser demos, and both clients consume the same API contract.
+
+Selecting **Go to map** switches workspaces and performs a coordinate-origin search centered on that evidence. Profiles and entities can use their own validated coordinate pair. A phone result can navigate only through a separately geolocated associated entity; the phone record itself never supplies or implies a location. Free-text locations do not enable the action.
 
 ## Run and test
 
@@ -39,6 +41,8 @@ The map searches by investigator-entered place, radius, optional keyword, and on
 - **X** returns recent posts only when X provides exact coordinates or a place bounding box. Place results use the bounding-box centroid and are labeled `place` accuracy.
 
 When X is unconfigured or unavailable, dataset results remain usable and the Map workspace displays a provider warning. Phone rows may appear as associated entity metadata but never create or imply a phone/device location. Free-text profile locations are not treated as post coordinates.
+
+Search-to-map handoffs query by latitude and longitude, bypass Nominatim, select the matching mapped record when available, and display whether the coordinates came from the record or an associated entity.
 
 Nominatim resolves only the investigator's entered search origin, server-side. OpenStreetMap attribution appears on the map. A marker is evidence tied to a source record, not proof of a person's present location.
 

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -62,6 +62,7 @@ const {
 const {
   MAP_ARCHIVE_KEY,
   buildMapSearchPath,
+  getMapTarget,
   normalizeMapCollection,
 } = require('./mapSearch.cjs');
 
@@ -382,6 +383,24 @@ function ResultRow({ title, subtitle, source, selected, onClick, action, childre
         {action && <Box sx={{ mt: 1.5 }}>{action}</Box>}
       </CardContent>
     </Card>
+  );
+}
+
+function GoToMapButton({ record, onGoToMap }) {
+  const target = getMapTarget(record);
+  if (!target) return null;
+  return (
+    <Button
+      size="small"
+      variant="outlined"
+      startIcon={<MapIcon />}
+      onClick={(event) => {
+        event.stopPropagation();
+        onGoToMap(target);
+      }}
+    >
+      Go to map
+    </Button>
   );
 }
 
@@ -882,8 +901,9 @@ function MapRecordDetail({ feature, onArchive, archived }) {
   );
 }
 
-function MapWorkspace() {
+function MapWorkspace({ handoff }) {
   const [place, setPlace] = React.useState('London');
+  const [coordinates, setCoordinates] = React.useState(null);
   const [radiusMiles, setRadiusMiles] = React.useState(25);
   const [keyword, setKeyword] = React.useState('');
   const [sources, setSources] = React.useState('datasets,x');
@@ -894,13 +914,27 @@ function MapWorkspace() {
   const [listMode, setListMode] = React.useState('results');
   const [archive, setArchive] = React.useState(loadMapArchive);
 
-  const runMapSearch = async () => {
+  const runMapSearch = async ({ coordinateTarget = coordinates, sourcesValue = sources, keywordValue = keyword } = {}) => {
     setLoading(true);
     setError('');
     try {
-      const payload = normalizeMapCollection(await requestJson(buildMapSearchPath({ place, radiusMiles, keyword, sources })));
+      const payload = normalizeMapCollection(await requestJson(buildMapSearchPath({
+        place: coordinateTarget ? '' : place,
+        latitude: coordinateTarget?.latitude,
+        longitude: coordinateTarget?.longitude,
+        radiusMiles,
+        keyword: keywordValue,
+        sources: sourcesValue,
+      })));
       setCollection(payload);
-      setSelected(payload.features[0] || null);
+      const requestedRecord = coordinateTarget?.recordId
+        ? payload.features.find((feature) => (
+          feature.id === coordinateTarget.recordId
+          || feature.id?.endsWith(`:${coordinateTarget.recordId}`)
+          || feature.properties?.provenance?.record_id === coordinateTarget.recordId
+        ))
+        : null;
+      setSelected(requestedRecord || payload.features[0] || null);
       setListMode('results');
     } catch (reason) {
       setError(reason.message);
@@ -908,6 +942,15 @@ function MapWorkspace() {
       setLoading(false);
     }
   };
+
+  React.useEffect(() => {
+    if (!handoff) return;
+    setPlace(handoff.label || `${handoff.latitude}, ${handoff.longitude}`);
+    setCoordinates(handoff);
+    setSources('datasets');
+    setKeyword('');
+    runMapSearch({ coordinateTarget: handoff, sourcesValue: 'datasets', keywordValue: '' });
+  }, [handoff?.requestId]);
 
   const archiveFeature = (feature) => {
     const next = [feature, ...archive.filter((item) => item.id !== feature.id)].slice(0, 100);
@@ -925,8 +968,20 @@ function MapWorkspace() {
         <Typography color="text.secondary">Explore evidence-backed locations from imported datasets and provider-supplied X geospatial data.</Typography>
       </Box>
       <Paper sx={{ p: 2.5 }}>
+        {handoff && coordinates?.requestId === handoff.requestId && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            Opened from Search using {coordinates.association === 'associated_entity' ? 'an associated entity’s' : 'the record’s'} explicit coordinates
+            {' '}({coordinates.locationAccuracy} accuracy, {humanize(coordinates.locationSource)} source).
+          </Alert>
+        )}
         <Stack direction={{ xs: 'column', lg: 'row' }} spacing={1.5} alignItems={{ lg: 'end' }}>
-          <TextField fullWidth label="Place" value={place} onChange={(event) => setPlace(event.target.value)} onKeyDown={(event) => event.key === 'Enter' && runMapSearch()} />
+          <TextField
+            fullWidth
+            label={coordinates ? 'Mapped result' : 'Place'}
+            value={place}
+            onChange={(event) => { setPlace(event.target.value); setCoordinates(null); }}
+            onKeyDown={(event) => event.key === 'Enter' && runMapSearch({ coordinateTarget: null })}
+          />
           <TextField label="Radius (miles)" type="number" value={radiusMiles} onChange={(event) => setRadiusMiles(event.target.value)} inputProps={{ min: 1, max: 1000 }} sx={{ minWidth: 150 }} />
           <TextField fullWidth label="Keyword (optional)" value={keyword} onChange={(event) => setKeyword(event.target.value)} />
           <TextField select label="Sources" value={sources} onChange={(event) => setSources(event.target.value)} sx={{ minWidth: 170 }}>
@@ -934,7 +989,7 @@ function MapWorkspace() {
             <MenuItem value="datasets">Datasets only</MenuItem>
             <MenuItem value="x">X only</MenuItem>
           </TextField>
-          <Button variant="contained" onClick={runMapSearch} disabled={loading} startIcon={loading ? <CircularProgress size={18} /> : <MapIcon />} sx={{ minWidth: 150 }}>
+          <Button variant="contained" onClick={() => runMapSearch()} disabled={loading} startIcon={loading ? <CircularProgress size={18} /> : <MapIcon />} sx={{ minWidth: 150 }}>
             {loading ? 'Searching…' : 'Search map'}
           </Button>
         </Stack>
@@ -944,7 +999,11 @@ function MapWorkspace() {
           {Object.entries(collection.providers || {}).map(([name, provider]) => (
             <Chip key={name} size="small" label={`${humanize(name)}: ${provider.status} (${provider.count})`} color={provider.status === 'ok' ? 'success' : 'warning'} variant="outlined" />
           ))}
-          <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>Search-origin place resolution uses server-side Nominatim with OpenStreetMap attribution.</Typography>
+          <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>
+            {coordinates
+              ? 'This search uses explicit evidence coordinates and does not geocode free-text record locations.'
+              : 'Search-origin place resolution uses server-side Nominatim with OpenStreetMap attribution.'}
+          </Typography>
         </Stack>
       </Paper>
       <Grid container spacing={2.5} alignItems="stretch">
@@ -1001,6 +1060,7 @@ function App() {
   const [notices, setNotices] = React.useState([]);
   const [history, setHistory] = React.useState(loadHistory);
   const [datasets, setDatasets] = React.useState([]);
+  const [mapHandoff, setMapHandoff] = React.useState(null);
 
   const reloadDatasets = React.useCallback(async () => {
     try { setDatasets(await requestJson('/datasets')); } catch { /* status surface handles availability */ }
@@ -1011,6 +1071,14 @@ function App() {
     const next = [{ id: `${Date.now()}-${type}`, type, query, count, searchedAt: new Date().toISOString() }, ...history].slice(0, 50);
     setHistory(next);
     localStorage.setItem(HISTORY_KEY, JSON.stringify(next));
+  };
+
+  const goToMap = (target) => {
+    setMapHandoff({ ...target, requestId: `${Date.now()}-${target.recordId || 'coordinates'}` });
+    setTab(1);
+    setSearchError('');
+    setProfileError('');
+    setNotices([]);
   };
 
   const inspectProfile = async (profileUrl) => {
@@ -1240,6 +1308,7 @@ function App() {
                     source={record.source_type === 'dataset' ? 'Dataset' : 'Live API'}
                     selected={selectedPhone === record}
                     onClick={() => setSelectedPhone(record)}
+                    action={getMapTarget(record) ? <GoToMapButton record={record} onGoToMap={goToMap} /> : null}
                   >
                     <Grid container spacing={1}>
                       <Grid item xs={6}><DetailItem label="Carrier" value={record.carrier_name} /></Grid>
@@ -1264,8 +1333,15 @@ function App() {
                       source={local ? 'Dataset' : 'Live scan'}
                       selected={local && selectedProfile?.id === record.id}
                       onClick={local ? () => { setProfileError(''); setSelectedProfile(record); } : undefined}
-                      action={!local && record.is_valid_profile
-                        ? <Button size="small" startIcon={<Search />} onClick={() => inspectProfile(record.profile_uri)}>Inspect profile</Button>
+                      action={(!local && record.is_valid_profile) || getMapTarget(record)
+                        ? (
+                          <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                            {!local && record.is_valid_profile && (
+                              <Button size="small" startIcon={<Search />} onClick={() => inspectProfile(record.profile_uri)}>Inspect profile</Button>
+                            )}
+                            <GoToMapButton record={record} onGoToMap={goToMap} />
+                          </Stack>
+                        )
                         : null}
                     >
                       {local ? (
@@ -1318,7 +1394,7 @@ function App() {
               : <ProfileDetail profile={selectedProfile} loading={profileLoading} error={profileError} />}
           />
         )}
-        {tab === 1 && <MapWorkspace />}
+        {tab === 1 && <MapWorkspace handoff={mapHandoff} />}
         {tab === 2 && <DatasetWorkspace datasets={datasets} reloadDatasets={reloadDatasets} />}
         {tab === 3 && <IntegrationsWorkspace onPlatformRefresh={refresh} />}
         {tab === 4 && (

--- a/src/mapSearch.cjs
+++ b/src/mapSearch.cjs
@@ -1,8 +1,55 @@
 const MAP_ARCHIVE_KEY = 'whoisit:map-archive';
 
-function buildMapSearchPath({ place, radiusMiles, keyword = '', sources = 'datasets,x', limit = 100 }) {
+function coordinatePair(latitudeValue, longitudeValue) {
+  if (latitudeValue === null || latitudeValue === undefined || latitudeValue === '') return null;
+  if (longitudeValue === null || longitudeValue === undefined || longitudeValue === '') return null;
+  const latitude = Number(latitudeValue);
+  const longitude = Number(longitudeValue);
+  if (!Number.isFinite(latitude) || latitude < -90 || latitude > 90) return null;
+  if (!Number.isFinite(longitude) || longitude < -180 || longitude > 180) return null;
+  return { latitude, longitude };
+}
+
+function getMapTarget(record) {
+  if (!record || typeof record !== 'object') return null;
+
+  // Phone records never supply location evidence themselves. They can only
+  // navigate through an explicitly geolocated associated entity.
+  const direct = record.record_type === 'phone'
+    ? null
+    : coordinatePair(record.latitude, record.longitude);
+  const entity = coordinatePair(record.entity?.latitude, record.entity?.longitude);
+  const coordinates = direct || entity;
+  if (!coordinates) return null;
+
+  const evidence = direct ? record : record.entity;
+  const recordId = evidence.id || record.id || null;
+  const label = evidence.location
+    || evidence.name
+    || record.name
+    || record.username
+    || record.phone_number
+    || `${coordinates.latitude.toFixed(5)}, ${coordinates.longitude.toFixed(5)}`;
+
+  return {
+    ...coordinates,
+    label,
+    recordId,
+    locationAccuracy: evidence.location_accuracy || 'unknown',
+    locationSource: evidence.location_source || 'unspecified',
+    association: direct ? 'record' : 'associated_entity',
+  };
+}
+
+function buildMapSearchPath({ place, latitude, longitude, radiusMiles, keyword = '', sources = 'datasets,x', limit = 100 }) {
   const normalizedPlace = String(place || '').trim();
-  if (!normalizedPlace) throw new Error('Enter a place to search.');
+  const coordinates = coordinatePair(latitude, longitude);
+  const hasCoordinateInput = latitude !== undefined || longitude !== undefined;
+  if (hasCoordinateInput && !coordinates) {
+    throw new Error('Latitude and longitude must be supplied together as valid coordinates.');
+  }
+  if (!normalizedPlace && !coordinates) throw new Error('Enter a place or coordinates to search.');
+  if (normalizedPlace && coordinates) throw new Error('Search by either place or coordinates, not both.');
   const radius = Number(radiusMiles);
   if (!Number.isFinite(radius) || radius <= 0 || radius > 1000) {
     throw new Error('Radius must be greater than 0 and no more than 1,000 miles.');
@@ -13,11 +60,16 @@ function buildMapSearchPath({ place, radiusMiles, keyword = '', sources = 'datas
     throw new Error('Select datasets, X, or both.');
   }
   const parameters = new URLSearchParams({
-    place: normalizedPlace,
     radius_miles: String(radius),
     sources: selected.join(','),
     limit: String(limit),
   });
+  if (coordinates) {
+    parameters.set('latitude', String(coordinates.latitude));
+    parameters.set('longitude', String(coordinates.longitude));
+  } else {
+    parameters.set('place', normalizedPlace);
+  }
   if (String(keyword).trim()) parameters.set('query', String(keyword).trim());
   return `/map/search?${parameters}`;
 }
@@ -34,4 +86,9 @@ function normalizeMapCollection(payload) {
   return { ...payload, features };
 }
 
-module.exports = { MAP_ARCHIVE_KEY, buildMapSearchPath, normalizeMapCollection };
+module.exports = {
+  MAP_ARCHIVE_KEY,
+  buildMapSearchPath,
+  getMapTarget,
+  normalizeMapCollection,
+};

--- a/tests/mapSearch.test.cjs
+++ b/tests/mapSearch.test.cjs
@@ -1,7 +1,11 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { buildMapSearchPath, normalizeMapCollection } = require('../src/mapSearch.cjs');
+const {
+  buildMapSearchPath,
+  getMapTarget,
+  normalizeMapCollection,
+} = require('../src/mapSearch.cjs');
 
 test('builds the canonical map query with source controls', () => {
   const path = buildMapSearchPath({
@@ -22,6 +26,66 @@ test('rejects invalid map input', () => {
   assert.throws(() => buildMapSearchPath({ place: '', radiusMiles: 10, sources: 'datasets' }), /place/);
   assert.throws(() => buildMapSearchPath({ place: 'London', radiusMiles: 0, sources: 'datasets' }), /Radius/);
   assert.throws(() => buildMapSearchPath({ place: 'London', radiusMiles: 10, sources: 'phones' }), /Select datasets/);
+  assert.throws(() => buildMapSearchPath({ latitude: 51.5, radiusMiles: 10, sources: 'datasets' }), /Latitude and longitude/);
+  assert.throws(() => buildMapSearchPath({ place: 'London', latitude: 51.5, longitude: -0.1, radiusMiles: 10, sources: 'datasets' }), /either place or coordinates/);
+});
+
+test('builds a coordinate search for a result handoff', () => {
+  const path = buildMapSearchPath({
+    latitude: 51.5074,
+    longitude: -0.1278,
+    radiusMiles: 25,
+    sources: 'datasets',
+  });
+  const url = new URL(path, 'http://localhost');
+  assert.equal(url.searchParams.get('place'), null);
+  assert.equal(url.searchParams.get('latitude'), '51.5074');
+  assert.equal(url.searchParams.get('longitude'), '-0.1278');
+  assert.equal(url.searchParams.get('sources'), 'datasets');
+});
+
+test('extracts direct profile coordinates for map navigation', () => {
+  assert.deepEqual(getMapTarget({
+    id: 'profile-1',
+    record_type: 'profile',
+    username: 'mapped_user',
+    latitude: 38.8816,
+    longitude: -77.091,
+    location_accuracy: 'exact',
+    location_source: 'provider_coordinates',
+  }), {
+    latitude: 38.8816,
+    longitude: -77.091,
+    label: 'mapped_user',
+    recordId: 'profile-1',
+    locationAccuracy: 'exact',
+    locationSource: 'provider_coordinates',
+    association: 'record',
+  });
+});
+
+test('uses an associated entity location for phone records', () => {
+  const target = getMapTarget({
+    id: 'phone-1',
+    record_type: 'phone',
+    phone_number: '+12025550111',
+    latitude: 1,
+    longitude: 2,
+    entity: {
+      id: 'entity-1',
+      name: 'London Map Demo',
+      latitude: 51.5074,
+      longitude: -0.1278,
+      location_accuracy: 'exact',
+      location_source: 'synthetic_fixture',
+    },
+  });
+  assert.equal(target.recordId, 'entity-1');
+  assert.equal(target.association, 'associated_entity');
+  assert.equal(target.latitude, 51.5074);
+  assert.equal(target.label, 'London Map Demo');
+  assert.equal(getMapTarget({ record_type: 'phone', latitude: 1, longitude: 2 }), null);
+  assert.equal(getMapTarget({ record_type: 'profile', latitude: null, longitude: null }), null);
 });
 
 test('keeps only valid GeoJSON point features', () => {


### PR DESCRIPTION
## What changed

- add a Go to map action when a search result has explicit coordinates
- open the native Map workspace with a coordinate-origin search and select the matching evidence record
- allow phone results to navigate only through a geolocated associated entity
- document the handoff and add unit coverage for coordinate validation and provenance

## Tested

- 18 Node tests pass
- verified profile-to-map and phone-to-associated-entity handoffs in the combined local demo
- confirmed free-text locations do not create a map target